### PR TITLE
投稿一覧機能

### DIFF
--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -1,15 +1,22 @@
 class FieldsController < ApplicationController
+  before_action :field_set, only: [:show]
+
   def index
     if Field.exists?(status: "touku")
       fields = Field.where(status: "touku")
-      @field = fields.order(updated_at: :desc)[0]
     elsif Field.exist?(status: "voting")
       fields = Field.where(status: "voting")
-      @field = fields.order(updated_at: :desc)[0]
     end
+    @field = fields.order(updated_at: :desc)[0]
     @fields = Field.where(status: "finished").order(updated_at: :desc)
   end
 
   def show
+    @haikus = @field.haikus.shuffle
+  end
+
+  private
+  def field_set
+    @field = Field.find(params[:id])
   end
 end

--- a/app/controllers/haikus_controller.rb
+++ b/app/controllers/haikus_controller.rb
@@ -3,10 +3,12 @@ class HaikusController < ApplicationController
   before_action :field_set, only: [:new, :create, :edit, :update]
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :move_to_top, only: [:edit]
-  before_action :move_to_edit, only: [:new]
 
   def new
-    unless Haiku.exists?(user_id: current_user.id, field_id: @field.id)
+    if Haiku.exists?(user_id: current_user.id, field_id: @field.id)
+      @haiku = @field.haikus.where(user_id: current_user.id)[0]
+      redirect_to "/fields/#{@haiku.field.id}/haikus/#{@haiku.id}/edit"
+    else
       @haiku = Haiku.new
     end
   end
@@ -48,12 +50,6 @@ class HaikusController < ApplicationController
   def move_to_top
     unless current_user.id == @haiku.user_id
       redirect_to root_path
-    end
-  end
-
-  def move_to_edit
-    if Haiku.exists?(user_id: current_user.id, field_id: @field.id)
-      redirect_to "/fields/#{@haiku.field.id}/haikus/#{@haiku.id}/edit"
     end
   end
 

--- a/app/views/fields/_field.html.erb
+++ b/app/views/fields/_field.html.erb
@@ -1,8 +1,12 @@
 <div class="card">
-  <%= link_to "第#{field.id}回", "#", class: :card__title %>
-  <%= link_to image_tag(field.theme.image, class: :card__img ), "#" %>
+  <% if field.status == "finished" %>
+    <%= link_to "第#{field.id}回", field_path(field.id), class: :card__title %>
+  <% else %>
+    <h2 class="page-heading"><%= "現在のお題" %></h2>
+  <% end %>
+  <%= link_to image_tag(field.theme.image, class: :card__img ), field_path(field.id) %>
   <div class="card__body">
     <%= "季節 : #{field.theme.season.name}" %>
-    <%= link_to "by #{field.theme.user.name}", user_path(field.theme.user_id), class: :card__user %>
+    <%= link_to "出題 : #{field.theme.user.name} 様", user_path(field.theme.user_id), class: :card__user %>
   </div>
 </div>

--- a/app/views/fields/_finished_show.html.erb
+++ b/app/views/fields/_finished_show.html.erb
@@ -1,0 +1,6 @@
+<div class="card">
+  <div class="card__body">
+    <%= haiku.content %>
+    <%= link_to haiku.user.name, "#", class: :card__user %>
+  </div>
+</div>

--- a/app/views/fields/_voting_show.html.erb
+++ b/app/views/fields/_voting_show.html.erb
@@ -1,0 +1,5 @@
+<div class="card">
+  <div class="card__body">
+    <%= haiku.content %>
+  </div>
+</div>

--- a/app/views/fields/show.html.erb
+++ b/app/views/fields/show.html.erb
@@ -1,0 +1,5 @@
+<% if @field.status == "voting" %>
+  <%= render partial: 'voting_show', collection: @haikus, as: 'haiku' %>
+<% elsif @field.status == "finished" %>
+  <%= render partial: 'finished_show', collection: @haikus, as: 'haiku' %>
+<% end%>

--- a/app/views/haikus/edit.html.erb
+++ b/app/views/haikus/edit.html.erb
@@ -1,18 +1,7 @@
 <div class="main">
   <div class="inner">
     <%# 現在のお題を表示 %>
-    <div class="card">
-      <h2 class="page-heading"><%= "現在のお題" %></h2>
-        <%= link_to "#{@field.theme.user.name}様より出題", user_path(@field.theme.user_id), class: :card__user %>
-        <%= link_to image_tag(@field.theme.image, class: :card__img ), "#" %>
-        <div class="card__body">
-          <h3><%= "季節 : #{@field.theme.season.name}" %></h3>
-        </div>
-    </div>
-    <%# 現在投稿中の俳句を表示 %>
-    <div class="haiku__wrapper">
-      <h2 class="page-heading"><%= "現在の俳句 : #{@haiku.content} (#{@haiku.content_sub})" %></h2>
-    </div>
+    <%= render 'shared/theme_card' %>
     <%# 俳句の編集フォーム %>
     <div class="form__wrapper">
       <h2 class="page-heading"><%= "俳句を編集" %></h2>

--- a/app/views/haikus/new.html.erb
+++ b/app/views/haikus/new.html.erb
@@ -1,14 +1,7 @@
 <div class="main">
   <div class="inner">
     <%# 現在のお題を表示 %>
-    <div class="card">
-      <h2 class="page-heading"><%= "現在のお題" %></h2>
-        <%= link_to "#{@field.theme.user.name}様より出題", user_path(@field.theme.user_id), class: :card__user %>
-        <%= link_to image_tag(@field.theme.image, class: :card__img ), "#" %>
-        <div class="card__body">
-          <h3><%= "季節 : #{@field.theme.season.name}" %></h3>
-        </div>
-    </div>
+    <%= render 'shared/theme_card' %>
     <%# 俳句の投稿フォーム %>
     <div class="form__wrapper">
       <h2 class="page-heading"><%= "俳句を作る" %></h2>

--- a/app/views/shared/_theme_card.html.erb
+++ b/app/views/shared/_theme_card.html.erb
@@ -1,0 +1,16 @@
+<div class="card">
+  <h2 class="page-heading"><%= "現在のお題" %></h2>
+    <%= link_to "#{@field.theme.user.name}様より出題", user_path(@field.theme.user_id), class: :card__user %>
+    <%= link_to image_tag(@field.theme.image, class: :card__img ), "#" %>
+    <div class="card__body">
+      <h3><%= "季節 : #{@field.theme.season.name}" %></h3>
+    </div>
+</div>
+
+<div class="haiku__wrapper">
+  <% if Haiku.exists?(user_id: current_user.id, field_id: @field.id) %>
+    <h2 class="page-heading"><%= "現在の俳句 : #{@haiku.content} (#{@haiku.content_sub})" %></h2>
+  <% else %>
+    <h2 class="page-heading"><%= "現在の俳句 : 投句されていません" %></h2>
+  <% end%>
+</div>


### PR DESCRIPTION
# What
fields#showで、status: "voting"／"finishedのfieldについて、haiku一覧を表示できるようにした。
status: "voting"のfieldについては、俳句のみをランダム順
status: "finished"のfieldについては、俳句＋投稿者名をランダム順
を表示
※status: "finished"のfieldに関しては、本来であれば得票数も表示し、順番も得票数順にする必要があるが、これは投票機能実装後に実装する

# Why
投票機能実装に必要な俳句一覧機能実装のため