### PR TITLE
得票関連の実装

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -254,6 +254,29 @@ a {
   margin: 0 10px;
 }
 
+/* 結果ページ */
+.haiku__result {
+  margin-top: 17.5px;
+  display: flex;
+}
+.haiku__rank{
+  color: red;
+  margin: 0 10px;
+}
+.haiku__points{
+  margin-right: 10px;
+}
+.finished__user {
+  display: block;
+  font-size: 12px;
+  color: #999;
+  text-align: left;
+  text-decoration: underline;
+}
+.haiku__body{
+  margin-bottom: 15px;
+}
+
 /* ユーザーページ */
 .user__wrapper{
   min-height: calc(100vh - 161px);

--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -12,7 +12,13 @@ class FieldsController < ApplicationController
   end
 
   def show
-    @haikus = @field.haikus.shuffle
+    if @field.status == "voting"
+      @haikus = @field.haikus.shuffle
+    elsif @field.status == "finished"
+      @haikus = @field.haikus.sort {|a,b| b.votes.size <=> a.votes.size}
+    else
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/views/fields/_finished_show.html.erb
+++ b/app/views/fields/_finished_show.html.erb
@@ -1,6 +1,14 @@
-<div class="card">
-  <div class="card__body">
-    <%= haiku.content %>
-    <%= link_to haiku.user.name, "#", class: :card__user %>
+<div class="vote">
+  <div class="haiku__result">
+    <div class="haiku__rank">
+        <%= "#{haiku_counter + 1}位" %>
+    </div>
+    <div class="haiku__points">
+        <%= "#{haiku.votes.count}点" %>
+    </div>
+  </div>
+  <div class="haiku__body">
+    <%= link_to haiku.user.name, "#", class: :finished__user %>
+    <div class="result__haiku"><%= haiku.content %></div>
   </div>
 </div>

--- a/lib/tasks/change_status.rake
+++ b/lib/tasks/change_status.rake
@@ -2,17 +2,19 @@ namespace :change_status do
 
   desc "Create a New Field."
   task create_new_field: :environment do
-    # "終わったFieldのステータスを変更"
+    # "終わったFieldを取得"
     fields = Field.where(status: "voting")
     finished_field = fields.order(updated_at: :desc)[-1]
+    # "終わったFieldの一位の回答を取得"
+    top_haiku = finished_field.haikus.sort {|a,b| b.votes.size <=> a.votes.size}[0]
+    top_user = top_haiku.user
+    top_theme = top_user.themes[0]
+    binding.pry
+    # "終わったFieldのステータスを変更"
     finished_field.update(status: "finished")
     # "新しいFieldを作成し、top_themeと紐づける"
-    themes = Theme.where(status: "set")
-    top_theme = themes.order(updated_at: :desc)[-1]
     Field.create(status: "touku", theme_id: top_theme.id)
     # "top_themeのステータスを変更"
-    themes = Theme.where(status: "set")
-    top_theme = themes.order(updated_at: :desc)[-1]
     top_theme.update(status: "used")
   end
 


### PR DESCRIPTION
# What
status: "finished"のfieldについては、得点順に俳句が表示されるようにした。
新規fieldが生成される際、その前のfieldで一位を取った人のお題が設定されるようにした。

# Why
得票関連の実装のため