### PR TITLE
ユーザー登録のメアド認証実装

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -383,7 +383,7 @@ a {
     font-size: 24px;
   }
   .card {
-    width: 48%;
+    width: 90%;
     margin-bottom: 40px;
   }
   .prototype_image{
@@ -401,7 +401,7 @@ a {
   }
   .card {
     width: 100%;
-    margin-bottom: 60px;
+    margin-bottom: 40px;
   }
   .card__title {
     font-size: 18px;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :confirmable
 
   has_many :themes
   has_many :haikus

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,10 @@
-<p>Welcome <%= @email %>!</p>
+<p>ご登録ありがとうございます。 <%= @email %> 様</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>以下のリンクから、メールアドレスの認証を行うことができます。</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to '「投句るうむ」でアカウントを認証する',
+            controller: 'devise/confirmations',
+            action: 'create',
+            confirmation_token: @token %></p>
+
+<p>※このメールに心当たりがない場合、一切の内容を無視してください。</p>

--- a/app/views/fields/index.html.erb
+++ b/app/views/fields/index.html.erb
@@ -1,5 +1,10 @@
 <main class="main">
   <div class="inner">
+    <% if user_signed_in? %>
+      <div class="greeting">
+        <%= "お待ちしておりました、#{current_user.name} 様" %>
+      </div>
+    <% end %>
     <div class="main_field_wrapper">
       <%= render partial: 'field', locals: { field: @field } %>
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,18 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # 開発環境でメール認証を受け取る
+  config.action_mailer.default_url_options = {  host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:"smtp.gmail.com",
+    domain: 'gmail.com',
+    port:587,
+    user_name: ENV["GOOGLE_MAIL_ADDRES"],
+    password: ENV["GOOGLE_APP_PASSWORD"],
+    authentication: :login
+  }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/db/migrate/20220225055816_add_confirmable_to_users.rb
+++ b/db/migrate/20220225055816_add_confirmable_to_users.rb
@@ -1,0 +1,8 @@
+class AddConfirmableToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_12_083445) do
+ActiveRecord::Schema.define(version: 2022_02_25_055816) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -71,6 +71,10 @@ ActiveRecord::Schema.define(version: 2022_02_12_083445) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# What
開発環境において、ユーザー登録をした際、登録したメールアドレスに認証メールが送られる
認証メールに記載されたリンクを踏むと、アカウントが認証され、ログインが可能となる（ログイン画面に遷移）

※本番環境での設定はデプロイ後に実施

# Why
ユーザー登録機能充実化のため